### PR TITLE
fix: ensure correct deep paths for posts

### DIFF
--- a/src/Revalidation.php
+++ b/src/Revalidation.php
@@ -36,23 +36,23 @@ class Revalidation {
 
 		$paths = [];
 
-		if ( Settings::get( 'revalidate_homepage', 'on', 'on_demand_revalidation_post_update_settings' ) === 'on' ) {
-			$paths[] = '/';
-		}
+        if ( Settings::get( 'revalidate_homepage', 'on', 'on_demand_revalidation_post_update_settings' ) === 'on' ) {
+            $paths[] = '/';
+        }
 
-        $post_permalink = get_permalink( $post );
-		$parse_permalink = parse_url( $post_permalink );
-        $page_path = '/';
+        $post_permalink  = get_permalink( $post );
+        $parse_permalink = parse_url( $post_permalink );
+        $page_path       = '/';
 
-        if( isset($parse_permalink['path']) ) {
+        if ( isset($parse_permalink['path']) ) {
             $page_path = $parse_permalink['path'];
         }
 
-		$paths[]   = substr( $page_path, -1 ) === '/' ? substr( $page_path, 0, -1 ) : $page_path;
+        $paths[] = substr( $page_path, -1 ) === '/' ? substr( $page_path, 0, -1 ) : $page_path;
 
-		$revalidate_paths = trim( Settings::get( 'revalidate_paths', '', 'on_demand_revalidation_post_update_settings' ) );
-		$revalidate_paths = preg_split( '/\r\n|\n|\r/', $revalidate_paths );
-		$revalidate_paths = Helpers::rewritePaths( $revalidate_paths, $post );
+        $revalidate_paths = Settings::get( 'revalidate_paths', '', 'on_demand_revalidation_post_update_settings' ) );
+        $revalidate_paths = preg_split( '/\r\n|\n|\r/', $revalidate_paths );
+        $revalidate_paths = Helpers::rewritePaths( $revalidate_paths, $post );
 
 		if ( $revalidate_paths ) {
 			foreach ( $revalidate_paths as $path ) {

--- a/src/Revalidation.php
+++ b/src/Revalidation.php
@@ -40,7 +40,14 @@ class Revalidation {
 			$paths[] = '/';
 		}
 
-		$page_path = "/$post->post_name";
+        $post_permalink = get_permalink( $post );
+		$parse_permalink = parse_url( $post_permalink );
+        $page_path = '/';
+
+        if( isset($parse_permalink['path']) ) {
+            $page_path = $parse_permalink['path'];
+        }
+
 		$paths[]   = substr( $page_path, -1 ) === '/' ? substr( $page_path, 0, -1 ) : $page_path;
 
 		$revalidate_paths = trim( Settings::get( 'revalidate_paths', '', 'on_demand_revalidation_post_update_settings' ) );
@@ -99,6 +106,7 @@ class Revalidation {
 		});
 
 		add_action('wp_ajax_revalidation-post-update-test', function () {
+
 			if ( ! current_user_can( 'edit_posts' ) ) {
 				$response = new WP_Error( 'rest_forbidden', __( 'You cannot edit posts.', 'on-demand-revalidation' ), [ 'status' => 401 ] );
 			}

--- a/src/Revalidation.php
+++ b/src/Revalidation.php
@@ -36,23 +36,23 @@ class Revalidation {
 
 		$paths = [];
 
-        if ( Settings::get( 'revalidate_homepage', 'on', 'on_demand_revalidation_post_update_settings' ) === 'on' ) {
-            $paths[] = '/';
-        }
+		if ( Settings::get( 'revalidate_homepage', 'on', 'on_demand_revalidation_post_update_settings' ) === 'on' ) {
+			$paths[] = '/';
+		}
 
-        $post_permalink  = get_permalink( $post );
-        $parse_permalink = parse_url( $post_permalink );
-        $page_path       = '/';
+		$post_permalink  = get_permalink( $post );
+		$parse_permalink = parse_url( $post_permalink );
+		$page_path       = '/';
 
-        if ( isset($parse_permalink['path']) ) {
-            $page_path = $parse_permalink['path'];
-        }
+		if ( isset($parse_permalink['path']) ) {
+			$page_path = $parse_permalink['path'];
+		}
 
-        $paths[] = substr( $page_path, -1 ) === '/' ? substr( $page_path, 0, -1 ) : $page_path;
+		$paths[] = substr( $page_path, -1 ) === '/' ? substr( $page_path, 0, -1 ) : $page_path;
 
-        $revalidate_paths = Settings::get( 'revalidate_paths', '', 'on_demand_revalidation_post_update_settings' ) );
-        $revalidate_paths = preg_split( '/\r\n|\n|\r/', $revalidate_paths );
-        $revalidate_paths = Helpers::rewritePaths( $revalidate_paths, $post );
+		$revalidate_paths = trim( Settings::get( 'revalidate_paths', '', 'on_demand_revalidation_post_update_settings' ) );
+		$revalidate_paths = preg_split( '/\r\n|\n|\r/', $revalidate_paths );
+		$revalidate_paths = Helpers::rewritePaths( $revalidate_paths, $post );
 
 		if ( $revalidate_paths ) {
 			foreach ( $revalidate_paths as $path ) {

--- a/src/Revalidation.php
+++ b/src/Revalidation.php
@@ -44,7 +44,7 @@ class Revalidation {
 		$parse_permalink = parse_url( $post_permalink );
 		$page_path       = '/';
 
-		if ( isset($parse_permalink['path']) ) {
+		if ( isset( $parse_permalink['path'] ) ) {
 			$page_path = $parse_permalink['path'];
 		}
 


### PR DESCRIPTION
Currently post paths use post_name which creates shallow paths for posts ignoring hierarchical or post type relationships such as:

'parent/post-name'
'blog/post-name'

Fix pulls the post permalink and parses out the path component thus preserving the full path of post