### PR TITLE
add required file to use plugin functions

### DIFF
--- a/on-demand-revalidation.php
+++ b/on-demand-revalidation.php
@@ -113,7 +113,11 @@ if ( ! class_exists( 'OnDemandRevalidation' ) ) :
 		 */
 		private function setup_constants(): void {
 
-			// Plugin version.
+            if (!function_exists('get_plugin_data')) {
+                require_once(ABSPATH . 'wp-admin/includes/plugin.php');
+            }
+
+            // Plugin version.
 			if ( ! defined( 'ON_DEMAND_REVALIDATION_VERSION' ) ) {
 				define( 'ON_DEMAND_REVALIDATION_VERSION', get_plugin_data( __FILE__ )['Version'] );
 			}


### PR DESCRIPTION
In a new installation of Wordpress, when I activate the plugins fail because some functions are not loaded. 
Looking for more information I check it in the last user contribued note: https://developer.wordpress.org/reference/functions/get_plugin_data/#user-contributed-notes

> Warning: get_plugin_data(..) is NOT available by default (not even in the admin). The pattern proposed by Aamer Shahzad with if ( ! function_exists( 'get_plugin_data' ) ) { require_once ... } seems to be mandatory before using get_plugin_data(..) (although not documented).
Otherwise, the whole site may crash with a fatal PHP error “call to undefined function”.

Them this pull request add the /wp-admin/includes/plugin.php file as is suggested in the notes.
