### PR TITLE
Feat/allow custom taxonomies

### DIFF
--- a/on-demand-revalidation.php
+++ b/on-demand-revalidation.php
@@ -6,7 +6,7 @@
  * Plugin URI:          https://wordpress.org/plugins/on-demand-revalidation
  * GitHub Plugin URI:   https://github.com/gdidentity/on-demand-revalidation
  * Description:         Next.js On-Demand Revalidation on the post update, revalidate specific paths on the post update.
- * Version:             1.0.16
+ * Version:             1.1.0
  * Author:              GD IDENTITY
  * Author URI:          https://gdidentity.sk
  * Text Domain:         on-demand-revalidation

--- a/readme.txt
+++ b/readme.txt
@@ -24,6 +24,8 @@ Feel free to create PR to [plugin Github repo](https://github.com/gdidentity/on-
 
 
 == Changelog ==
+= 1.1.0 =
+- Allow custom taxonomies revalidation from @humet
 
 = 1.0.16 =
 - fix from @slimzc

--- a/src/Admin/Settings.php
+++ b/src/Admin/Settings.php
@@ -91,8 +91,8 @@ class Settings {
 			[
 				'name'        => 'revalidate_paths',
 				'label'       => __( 'Additional paths to revalidate on Post update', 'on-demand-revalidation' ),
-				'desc'        => 'One path per row.<br/><br/><i>Available current Post placeholders:</i><br/><code>%slug%</code> <code>%author_nicename%</code> <code>%categories%</code> <code>%tags%</code>',
-				'placeholder' => '/category/%categories%',
+				'desc'        => 'One path per row.<br/><br/><i>Available current Post placeholders:</i><br/><code>%slug%</code> <code>%author_nicename%</code> <code>%author_username%</code> <code>%category%</code> <code>%post_tag%</code> <code>%custom_taxonomy%</code><br/><br/><i>Note:</i> Replace <code>%custom_taxonomy%</code> with your custom taxonomy name.',
+				'placeholder' => '/category/%category%',
 				'type'        => 'textarea',
 			],
 			[


### PR DESCRIPTION
This pull request introduces several enhancements to the plugin, improving its flexibility and usability.

### Changes Include:

1. The `rewritePaths` function in the `Helpers` class now supports **all taxonomies** associated with a post, not just categories. This makes the plugin more flexible and compatible with a wider range of Wordpress setups.

2. We've added an additional placeholder `%author_username%` for usage in revalidation paths, allowing inclusion of the post author's username.

3. Improved support for paths with **multiple placeholders** of the same or different types. This ensures that all placeholders in a path are correctly replaced, not just the first occurrence of each type.

4. The user interface in the Settings has been updated to guide users about using taxonomy names, including 'category', 'post_tag', or any custom taxonomy.

These enhancements greatly increase the plugin's flexibility and its ability to handle a variety of Wordpress configurations and setups. Importantly, the changes are backward compatible, ensuring that the plugin continues to work as expected for users who do not wish to utilize these new features.

### Testing

The changes have been tested and verified in a Wordpress environment. For ensuring maximum compatibility, it is recommended to perform further testing in various setups.

