### PR TITLE
fix: reduce unnecessary revalidations

### DIFF
--- a/on-demand-revalidation.php
+++ b/on-demand-revalidation.php
@@ -6,7 +6,7 @@
  * Plugin URI:          https://wordpress.org/plugins/on-demand-revalidation
  * GitHub Plugin URI:   https://github.com/gdidentity/on-demand-revalidation
  * Description:         Next.js On-Demand Revalidation on the post update, revalidate specific paths on the post update.
- * Version:             1.1.0
+ * Version:             1.1.1
  * Author:              GD IDENTITY
  * Author URI:          https://gdidentity.sk
  * Text Domain:         on-demand-revalidation

--- a/src/Revalidation.php
+++ b/src/Revalidation.php
@@ -9,22 +9,35 @@ use WP_Error;
 class Revalidation {
 
 	public static function init() {
-		add_action('wp_insert_post', function ( $post_ID, $post, $update ) {
-			if ( wp_is_post_revision( $post_ID ) ) {
-				return;
-			}
-
-			self::revalidatePost( $post );
-		}, 10, 3);
-
-		add_action('transition_post_status', function ( $new_status, $old_status, $post ) {
-			self::revalidatePost( $post );
-		}, 10, 3);
-
-		add_action('on_demand_revalidation_on_post_update', function ( $post ) {
-			self::revalidate( $post );
-		}, 10, 1);
+		add_action('save_post', [self::class, 'handleSavePost'], 10, 2);
+		add_action('transition_post_status', [self::class, 'handleTransitionPostStatus'], 10, 3);
+		add_action('on_demand_revalidation_on_post_update', [self::class, 'revalidate'], 10, 1);
 	}
+	
+	public static function handleSavePost($post_ID, $post) {
+		$excludedStatuses = ['auto-draft', 'inherit', 'draft', 'trash'];
+		
+		if (isset($post->post_status) && in_array($post->post_status, $excludedStatuses)) {
+			return;
+		}
+		
+		if ((defined('DOING_AUTOSAVE') && DOING_AUTOSAVE) || (defined('DOING_AJAX') && DOING_AJAX)) {
+			return;
+		}
+	
+		if (false !== wp_is_post_revision($post_id)) {
+			return;
+		}
+		
+		self::revalidatePost($post);
+	}
+	
+	public static function handleTransitionPostStatus($new_status, $old_status, $post) {
+		if ((($old_status !== 'draft' && $old_status !== 'trash') && $new_status === 'trash') ||
+			($old_status === 'publish' && $new_status === 'draft')) {
+			self::revalidatePost($post);
+		}
+	}	
 
 	static function revalidatePost( $post ) {
 		if ( Settings::get( 'disable_cron', 'on', 'on_demand_revalidation_post_update_settings' ) === 'on' ) {


### PR DESCRIPTION
## Pull Request Description

The focus of this PR is to optimise the revalidation process by ensuring that the revalidation function is only called when necessary, i.e., when a change that affects the front end is triggered. 

#### Changes Implemented:

1. **Optimised Revalidation Triggering:** 
   - Previously, the revalidation function was being called excessively, even during non-frontend changes such as draft saves. 
   - Now, the revalidation is triggered only during events that modify the frontend, such as when a post is published or trashed.

2. **Refactored Action Handling:** 
   - The logic handling different WordPress actions has been refactored and separated into two methods: `handleSavePost` and `handleTransitionPostStatus`. 
   - This separation makes the code more manageable and easier to understand.

3. **Improved Code Readability and Maintainability:** 
   - Extraneous code and checks were removed and replaced with a streamlined version that maintains functionality while improving readability.

This optimised implementation reduces unnecessary server requests and enhances the overall efficiency of the plugin.
