### PR TITLE
Fix "paths array empty if `revalidate_paths` is not defined"

### DIFF
--- a/src/Revalidation.php
+++ b/src/Revalidation.php
@@ -161,8 +161,6 @@ class Revalidation {
 		if ( ! empty( $revalidate_paths ) ) {
 			$revalidate_paths = preg_split( '/\r\n|\n|\r/', $revalidate_paths );
 			$revalidate_paths = Helpers::rewrite_placeholders( $revalidate_paths, $post );
-		} else {
-			$paths = array();
 		}
 
 		$revalidate_tags = trim( Settings::get( 'revalidate_tags', '', 'on_demand_revalidation_post_update_settings' ) );


### PR DESCRIPTION
The `$paths` array returns empty if the `Additional paths to revalidate on Post update` setting is empty.  The only way for revalidation to work is to have _something_ defined in this field.  This fix allows for default behavior while also supporting additional routes to be revalidated on `save_post`.