### PR TITLE
Fix "tags array populated by paths filter"

### DIFF
--- a/src/Revalidation.php
+++ b/src/Revalidation.php
@@ -183,7 +183,7 @@ class Revalidation {
 		}
 
 		$paths = apply_filters( 'on_demand_revalidation_paths', $paths, $post );
-		$tags  = apply_filters( 'on_demand_revalidation_paths', $tags, $post );
+		$tags  = apply_filters( 'on_demand_revalidation_tags', $tags, $post );
 
 		$data = array(
 			'postId' => $post->ID,


### PR DESCRIPTION
When leveraging `on_demand_revalidation_paths` filter, the `$tags` array is populated because of mis-assignment of filter.  This bug results in the same route being passed to the revalidation route handler, appearing in both `paths` and `tags` array.

The fix is to create a separate filter for tags to prevent paths logic applying to tags.